### PR TITLE
Refine starfield and orbit rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,15 +117,15 @@
   // -------- Data (scaled/approx) --------
   // Distances in AU compressed, radii in Earth radii compressed logarithmically
   const bodies=[
-    {id:'sun',name:'Sol',color:'#ffd27a', r:109, dist:0, year:0, rot:25, tilt:7.25, ring:false},
-    {id:'mercury',name:'Mercurio',color:'#a8a8a8', r:0.383, dist:0.39, year:0.24, rot:58.6, tilt:0.03},
-    {id:'venus',name:'Venus',color:'#f5c97a', r:0.949, dist:0.72, year:0.62, rot:-243, tilt:177.4},
-    {id:'earth',name:'Tierra',color:'#7fc8ff', r:1, dist:1, year:1, rot:1, tilt:23.4},
-    {id:'mars',name:'Marte',color:'#ff9b6b', r:0.532, dist:1.52, year:1.88, rot:1.03, tilt:25.2},
-    {id:'jupiter',name:'Júpiter',color:'#f4d7a1', r:11.21, dist:5.2, year:11.86, rot:0.41, tilt:3.1},
-    {id:'saturn',name:'Saturno',color:'#f7e2ac', r:9.45, dist:9.58, year:29.46, rot:0.45, tilt:26.7, ring:true},
-    {id:'uranus',name:'Urano',color:'#a7f1ff', r:4.01, dist:19.2, year:84.01, rot:-0.72, tilt:97.8, ring:true},
-    {id:'neptune',name:'Neptuno',color:'#7fb7ff', r:3.88, dist:30.05, year:164.8, rot:0.67, tilt:28.3}
+    {id:'sun',name:'Sol',color:'#ffd27a', r:109, dist:0, year:0, rot:25, orbitTilt:0, axialTilt:7.25, ring:false},
+    {id:'mercury',name:'Mercurio',color:'#a8a8a8', r:0.383, dist:0.39, year:0.24, rot:58.6, orbitTilt:7.0, axialTilt:0.03},
+    {id:'venus',name:'Venus',color:'#f5c97a', r:0.949, dist:0.72, year:0.62, rot:-243, orbitTilt:3.4, axialTilt:177.4},
+    {id:'earth',name:'Tierra',color:'#7fc8ff', r:1, dist:1, year:1, rot:1, orbitTilt:0.0, axialTilt:23.4},
+    {id:'mars',name:'Marte',color:'#ff9b6b', r:0.532, dist:1.52, year:1.88, rot:1.03, orbitTilt:1.85, axialTilt:25.2},
+    {id:'jupiter',name:'Júpiter',color:'#f4d7a1', r:11.21, dist:5.2, year:11.86, rot:0.41, orbitTilt:1.3, axialTilt:3.1},
+    {id:'saturn',name:'Saturno',color:'#f7e2ac', r:9.45, dist:9.58, year:29.46, rot:0.45, orbitTilt:2.5, axialTilt:26.7, ring:true},
+    {id:'uranus',name:'Urano',color:'#a7f1ff', r:4.01, dist:19.2, year:84.01, rot:-0.72, orbitTilt:0.8, axialTilt:97.8, ring:true},
+    {id:'neptune',name:'Neptuno',color:'#7fb7ff', r:3.88, dist:30.05, year:164.8, rot:0.67, orbitTilt:1.8, axialTilt:28.3}
   ];
   // moons (subset)
   const moons=[
@@ -162,7 +162,7 @@
   uniform vec2 res; uniform float t; uniform float speed; uniform mat3 camR; uniform float camD; 
   // body data limits
   #define MAXB 9
-  struct Body{vec3 color; float rad; float dist; float year; float tilt; float rot; float ring;};
+  struct Body{vec3 color; float rad; float dist; float year; float orbitTilt; float axialTilt; float rot; float ring;};
   uniform Body bodies[MAXB];
   // moons (limited)
   #define MAXM 5
@@ -189,8 +189,8 @@
     float e = 0.06; // common small eccentricity
     float a=b.dist; float bminor=a*sqrt(1.-e*e);
     vec3 p = vec3(a*cos(ang), 0., bminor*sin(ang));
-    // orbital tilt
-    p = rotX(radians(b.tilt))*p;
+    // orbital inclination
+    p = rotX(radians(b.orbitTilt))*p;
     return p;
   }
 
@@ -199,7 +199,8 @@
     float r = m.dist*6.; // visually exaggerated
     vec3 p = vec3(r*cos(ang), 0., r*sin(ang));
     vec3 hp = planetPos(host);
-    return hp + rotX(radians(host.tilt))*p;
+    // align moon plane with host axial tilt
+    return hp + rotX(radians(host.axialTilt))*p;
   }
 
   // signed distance functions
@@ -222,7 +223,7 @@
       if(di<d){d=di; sid=i; skind=0;}
       // rings
       if(b.ring>0.5){
-        vec3 rp = p-bp; rp = rotX(radians(b.tilt))*rp; // align to planetary plane
+        vec3 rp = p-bp; rp = rotX(radians(b.axialTilt))*rp; // align to planetary plane
         float dr = sdRing(rp, r*1.7, r*3.0, r*0.06);
         if(dr<d){d=dr; sid=i; skind=1;}
       }
@@ -247,7 +248,7 @@
 
   vec3 bodyColor(int id, int kind, vec3 p){
     if(kind==1){ // rings
-      Body b=bodies[id]; vec3 bp=planetPos(b); vec3 rp = p-bp; rp=rotX(radians(b.tilt))*rp; float d=length(rp.xz);
+      Body b=bodies[id]; vec3 bp=planetPos(b); vec3 rp = p-bp; rp=rotX(radians(b.axialTilt))*rp; float d=length(rp.xz);
       float band = smoothstep(0.,1.,fract(d*20.)); float alpha = smoothstep(0.,1.,sin(d*50.));
       return mix(vec3(0.85,0.8,0.7), vec3(0.6,0.55,0.5), band*alpha);
     }
@@ -275,9 +276,15 @@
     }
 
     // background starfield
-    vec3 col = vec3(0.01,0.015,0.03);
-    float s = hash12(rd.xy*res+vec2(t*10.0));
-    col += pow(s,50.0)*0.6; // sparse stars
+    vec3 col = vec3(0.008,0.012,0.024);
+    vec2 starSeed = rd.xy*res*1.8;
+    float s1 = hash12(starSeed);
+    float s2 = hash12(rd.yx*res*3.4 + 21.0);
+    float starA = smoothstep(0.992,1.0,s1);
+    float starB = smoothstep(0.9975,1.0,s2);
+    vec3 tint = mix(vec3(0.55,0.65,1.0), vec3(1.0,0.9,0.82), hash12(starSeed+3.7));
+    col += starA*0.35*tint;
+    col += starB*0.85*vec3(1.0,0.95,0.9);
 
     // sun light
     vec3 sunP = planetPos(bodies[0]);
@@ -349,7 +356,8 @@
     gl.uniform1f(uBody(i,'rad'), b.r);
     gl.uniform1f(uBody(i,'dist'), b.dist*4.0); // visual scale of AU
     gl.uniform1f(uBody(i,'year'), Math.max(0.0001, b.year*0.7));
-    gl.uniform1f(uBody(i,'tilt'), b.tilt);
+    gl.uniform1f(uBody(i,'orbitTilt'), b.orbitTilt||0);
+    gl.uniform1f(uBody(i,'axialTilt'), b.axialTilt||0);
     gl.uniform1f(uBody(i,'rot'), b.rot);
     gl.uniform1f(uBody(i,'ring'), b.ring?1.0:0.0);
   });
@@ -449,7 +457,7 @@
       for(let k=0;k<=64;k++){
         const ang=k/64*TAU; let px=a*Math.cos(ang), pz=bminor*Math.sin(ang); let py=0;
         // orbital tilt X
-        const c=Math.cos(b.tilt*Math.PI/180), s=Math.sin(b.tilt*Math.PI/180); const y=py*c - pz*s; const z=py*s + pz*c;
+        const c=Math.cos(b.orbitTilt*Math.PI/180), s=Math.sin(b.orbitTilt*Math.PI/180); const y=py*c - pz*s; const z=py*s + pz*c;
         const P=proj([px,y,z]); if(k===0) ox.moveTo(P[0],P[1]); else ox.lineTo(P[0],P[1]);
       }
       ox.strokeStyle='rgba(137,160,255,0.35)'; ox.lineWidth=1; ox.stroke();
@@ -470,8 +478,8 @@
       const z=p[0]*camR[2]+p[1]*camR[5]+p[2]*camR[8]+camD; const s=500/(z+1e-3); return [cx + x*s/dpr, cy + y*s/dpr, z];
     }
     bodies.forEach((b,i)=>{
-      const ang=tSim/Math.max(0.0001,b.year*0.7); const e=0.06; const a=b.dist*4.0; const bmn=a*Math.sqrt(1-e*e); 
-      let px=a*Math.cos(ang), pz=bmn*Math.sin(ang), py=0; const c=Math.cos(b.tilt*Math.PI/180), s=Math.sin(b.tilt*Math.PI/180);
+      const ang=tSim/Math.max(0.0001,b.year*0.7); const e=0.06; const a=b.dist*4.0; const bmn=a*Math.sqrt(1-e*e);
+      let px=a*Math.cos(ang), pz=bmn*Math.sin(ang), py=0; const c=Math.cos(b.orbitTilt*Math.PI/180), s=Math.sin(b.orbitTilt*Math.PI/180);
       const y=py*c - pz*s; const z=py*s + pz*c; const P=proj([px,y,z]);
       const el=labelEls[i]; el.style.left=P[0]+"px"; el.style.top=P[1]+"px"; el.style.opacity = (P[2]>1?1:0.2);
     })


### PR DESCRIPTION
## Summary
- separate orbital and axial tilt data for planets to render orbits and rings with accurate inclinations
- adjust uniform uploads and orbit/label overlays to use the new tilt parameters
- refresh the starfield shader to produce a steadier, crisper background sky

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d750f266988324aecbca742c52ce90